### PR TITLE
Add a method for Android that allows you to copy a file just given its URI 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file",
-  "version": "6.0.1",
+  "version": "6.0.1-j5.1",
   "description": "Cordova File Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-file"
-      version="6.0.1">
+      version="6.0.1-j5.1">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -22,9 +22,11 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
+import android.provider.MediaStore;
 import android.util.Base64;
 
 import org.apache.cordova.CallbackContext;
@@ -523,6 +525,17 @@ public class FileUtils extends CordovaPlugin {
                 }
             }, rawArgs, callbackContext);
         }
+        else if (action.equals("copyUriTo")) {
+            threadhelper( new FileOp( ){
+                public void run(JSONArray args) throws JSONException, NoModificationAllowedException, IOException, InvalidModificationException, EncodingException, FileExistsException {
+                    Uri srcUri = Uri.parse(args.getString(0));
+                    String newParent=args.getString(1);
+                    String newName=args.getString(2);
+                    JSONObject entry = copyUriTo(srcUri, newParent, newName);
+                        callbackContext.success(entry);
+                }
+            }, rawArgs, callbackContext);
+        }
         else if (action.equals("readEntries")) {
             threadhelper( new FileOp( ){
                 public void run(JSONArray args) throws FileNotFoundException, JSONException, MalformedURLException {
@@ -795,6 +808,41 @@ public class FileUtils extends CordovaPlugin {
         }
 
         return destFs.copyFileToURL(destURL, newName, srcFs, srcURL, move);
+    }
+
+    private JSONObject copyUriTo(Uri srcUri, String destURLstr, String newName) throws JSONException, NoModificationAllowedException, IOException, InvalidModificationException, EncodingException, FileExistsException {
+        if (srcUri == null || destURLstr == null) {
+            // either no source or no destination provided
+            throw new FileNotFoundException();
+        }
+
+        if (newName == null || newName.equals("null")) {
+            Cursor cursor = null;
+            try {
+                String[] projection =  new String[] {MediaStore.MediaColumns.DISPLAY_NAME};
+                cursor = this.cordova.getContext().getContentResolver().query(
+                        srcUri, projection, null, null, null
+                );
+                boolean success = cursor.moveToFirst();
+                if (!success) {
+                    throw new FileNotFoundException("Source file not found");
+                }
+                newName = cursor.getString(cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME));
+            } finally {
+                if (cursor != null)
+                    cursor.close();
+            }
+
+        }
+
+        LocalFilesystemURL destURL = LocalFilesystemURL.parse(destURLstr);
+        Filesystem destFs = this.filesystemForURL(destURL);
+
+        // Check for invalid file name
+        if (newName != null && newName.contains(":")) {
+            throw new EncodingException("Bad file name");
+        }
+        return destFs.copyFileToURL(destURL, newName, srcUri);
     }
 
     /**

--- a/src/android/Filesystem.java
+++ b/src/android/Filesystem.java
@@ -213,9 +213,13 @@ public abstract class Filesystem {
 	}
 
     protected LocalFilesystemURL makeDestinationURL(String newName, LocalFilesystemURL srcURL, LocalFilesystemURL destURL, boolean isDirectory) {
+        return makeDestinationURL(newName, srcURL.uri, destURL, isDirectory);
+    }
+
+    protected LocalFilesystemURL makeDestinationURL(String newName, Uri srcUri, LocalFilesystemURL destURL, boolean isDirectory) {
         // I know this looks weird but it is to work around a JSON bug.
         if ("null".equals(newName) || "".equals(newName)) {
-            newName = srcURL.uri.getLastPathSegment();;
+            newName = srcUri.getLastPathSegment();;
         }
 
         String newDest = destURL.uri.toString();
@@ -259,6 +263,23 @@ public abstract class Filesystem {
         if (move) {
             srcFs.removeFileAtLocalURL(srcURL);
         }
+        return getEntryForLocalURL(destination);
+    }
+
+    public JSONObject copyFileToURL(LocalFilesystemURL destURL, String newName,
+                                     Uri srcUri) throws IOException, InvalidModificationException, JSONException, NoModificationAllowedException, FileExistsException {
+        final LocalFilesystemURL destination = makeDestinationURL(newName, srcUri, destURL, false);
+        CordovaResourceApi.OpenForReadResult ofrr = resourceApi.openForRead(srcUri);
+        OutputStream os = null;
+        try {
+            os = getOutputStreamForURL(destination);
+        } catch (IOException e) {
+            ofrr.inputStream.close();
+            throw e;
+        }
+        // Closes streams.
+        resourceApi.copyResource(ofrr, os);
+
         return getEntryForLocalURL(destination);
     }
 

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-file-tests"
-    version="6.0.1">
+    version="6.0.1-j5.1">
 
     <name>Cordova File Plugin Tests</name>
     <license>Apache 2.0</license>

--- a/www/Entry.js
+++ b/www/Entry.js
@@ -175,6 +175,33 @@ Entry.prototype.copyTo = function (parent, newName, successCallback, errorCallba
     exec(success, fail, 'File', 'copyTo', [srcURL, parent.toInternalURL(), name]);
 };
 
+Entry.copyUriTo = function (srcUri, parent, newName, successCallback, errorCallback) {
+    argscheck.checkArgs('oSFF', 'Entry.copyUriTo', arguments);
+    var fail = errorCallback && function (code) {
+        errorCallback(new FileError(code));
+    };
+    // success callback
+    var success = function (entry) {
+        if (entry) {
+            if (successCallback) {
+                // create appropriate Entry object
+                var newFSName = entry.filesystemName || (entry.filesystem && entry.filesystem.name);
+                var fs = newFSName ? new FileSystem(newFSName, { name: '', fullPath: '/' }) : new FileSystem(parent.filesystem.name, { name: '', fullPath: '/' }); // eslint-disable-line no-undef
+                var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL) : new (require('cordova-plugin-file.FileEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL);
+                successCallback(result);
+            }
+        } else {
+            // no Entry object returned
+            if (fail) {
+                fail(FileError.NOT_FOUND_ERR);
+            }
+        }
+    };
+
+    // copy
+    exec(success, fail, 'File', 'copyUriTo', [srcUri, parent.toInternalURL(), newName]);
+};
+
 /**
  * Return a URL that can be passed across the bridge to identify this entry.
  */

--- a/www/Entry.js
+++ b/www/Entry.js
@@ -176,7 +176,7 @@ Entry.prototype.copyTo = function (parent, newName, successCallback, errorCallba
 };
 
 Entry.copyUriTo = function (srcUri, parent, newName, successCallback, errorCallback) {
-    argscheck.checkArgs('oSFF', 'Entry.copyUriTo', arguments);
+    argscheck.checkArgs('SoSFF', 'Entry.copyUriTo', arguments);
     var fail = errorCallback && function (code) {
         errorCallback(new FileError(code));
     };


### PR DESCRIPTION
We are having difficulty resolving native URLs in certain cases on Android, so this adds a method that largely duplicates the existing logic but which only requires a file's URI as opposed to being given a FileEntry (which requires a native URL). The new method was tested as part of https://gitlab.sjsoft.com/j5-product/j5-mobile/merge_requests/1031