### PR TITLE
Revert version number changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file",
-  "version": "6.0.1-j5.1",
+  "version": "6.0.1",
   "description": "Cordova File Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-file"
-      version="6.0.1-j5.1">
+      version="6.0.1">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-file-tests"
-    version="6.0.1-j5.1">
+    version="6.0.1">
 
     <name>Cordova File Plugin Tests</name>
     <license>Apache 2.0</license>


### PR DESCRIPTION
The version number changes led to errors like 

```
[2020-10-21T07:38:37.008Z] Failed to install 'cordova-plugin-file-transfer': CordovaError: Version of installed plugin: "cordova-plugin-file@6.0.1-j5.1" does not satisfy dependency plugin requirement "cordova-plugin-file@>=5.0.0". Try --force to use installed plugin as dependency.
[2020-10-21T07:38:37.008Z]     at C:\Users\j5ops\j5-environments\28.0\cordova\node_modules\cordova\node_modules\cordova-lib\src\plugman\install.js:557:37
[2020-10-21T07:38:37.008Z]     at _fulfilled (C:\Users\j5ops\j5-environments\28.0\cordova\node_modules\cordova\node_modules\q\q.js:787:54)
[2020-10-21T07:38:37.008Z]     at C:\Users\j5ops\j5-environments\28.0\cordova\node_modules\cordova\node_modules\q\q.js:816:30
[2020-10-21T07:38:37.008Z]     at Promise.promise.promiseDispatch (C:\Users\j5ops\j5-environments\28.0\cordova\node_modules\cordova\node_modules\q\q.js:749:13)
[2020-10-21T07:38:37.008Z]     at C:\Users\j5ops\j5-environments\28.0\cordova\node_modules\cordova\node_modules\q\q.js:509:49
[2020-10-21T07:38:37.008Z]     at flush (C:\Users\j5ops\j5-environments\28.0\cordova\node_modules\cordova\node_modules\q\q.js:108:17)
[2020-10-21T07:38:37.008Z]     at processTicksAndRejections (internal/process/task_queues.js:79:11)
[2020-10-21T07:38:37.008Z] Failed to restore plugin "cordova-plugin-file-transfer" from config.xml. You might need to try adding it again. Error: Version of installed plugin: "cordova-plugin-file@6.0.1-j5.1" does not satisfy dependency plugin requirement "cordova-plugin-file@>=5.0.0". Try --force to use installed plugin as dependency
```

So backing them out.
